### PR TITLE
Update TemporaryQueueReplyManager.java

### DIFF
--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/reply/TemporaryQueueReplyManager.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/reply/TemporaryQueueReplyManager.java
@@ -136,7 +136,7 @@ public class TemporaryQueueReplyManager extends ReplyManagerSupport {
          * Bind consumer to channel
          */
         private void start() throws IOException {
-            tag = channel.basicConsume(getReplyTo(), endpoint.isAutoAck(), this);
+            tag = channel.basicConsume(getReplyTo(), true, this);
         }
 
         /**


### PR DESCRIPTION
Fix for CAMEL-12746
https://issues.apache.org/jira/browse/CAMEL-12746
Temp reply queues will now always be created with autoAck=true.